### PR TITLE
Revert "Switch to API version 3.0"

### DIFF
--- a/MMM-DynamicWeather.js
+++ b/MMM-DynamicWeather.js
@@ -105,7 +105,7 @@ Module.register("MMM-DynamicWeather", {
         this.weatherTimeout = null;
         this.holidayTimeout = null;
         this.allEffects = [];
-        this.url = "https://api.openweathermap.org/data/3.0/weather?appid=" + this.config.api_key;
+        this.url = "https://api.openweathermap.org/data/2.5/weather?appid=" + this.config.api_key;
         if (this.config.lat && this.config.lon) {
             this.url += "&lat=" + this.config.lat + "&lon=" + this.config.lon;
         }

--- a/MMM-DynamicWeather.ts
+++ b/MMM-DynamicWeather.ts
@@ -128,7 +128,7 @@ Module.register("MMM-DynamicWeather", {
     this.weatherTimeout = null;
     this.holidayTimeout = null;
     this.allEffects = [] as Effect[];
-    this.url = "https://api.openweathermap.org/data/3.0/weather?appid=" + this.config.api_key;
+    this.url = "https://api.openweathermap.org/data/2.5/weather?appid=" + this.config.api_key;
 
     if (this.config.lat && this.config.lon) {
       this.url += "&lat=" + this.config.lat + "&lon=" + this.config.lon;


### PR DESCRIPTION
Reverts scottcl88/MMM-DynamicWeather#48

This was not needed. Per the documentation [here](https://openweathermap.org/one-call-transfer), only the "One Call" api is changing, which this module is not using.